### PR TITLE
Lighthouse Audit

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,4 +1,1 @@
 require('./bootstrap');
-import hljs from 'highlight.js';
-
-hljs.initHighlightingOnLoad();

--- a/resources/js/bootstrap.js
+++ b/resources/js/bootstrap.js
@@ -1,4 +1,4 @@
-window._ = require('lodash');
+// window._ = require('lodash');
 
 /**
  * We'll load the axios HTTP library which allows us to easily issue requests

--- a/resources/js/post.js
+++ b/resources/js/post.js
@@ -1,0 +1,3 @@
+import hljs from 'highlight.js';
+
+hljs.initHighlightingOnLoad();

--- a/resources/views/layouts/base.blade.php
+++ b/resources/views/layouts/base.blade.php
@@ -49,7 +49,8 @@
 </div>
 
 @include('layouts.footer')
+@include('layouts.scripts')
 
-<script src="{{ mix('js/app.js') }}"></script>
+@yield('scripts')
 
 @include('partials.fathom')

--- a/resources/views/layouts/scripts.blade.php
+++ b/resources/views/layouts/scripts.blade.php
@@ -1,0 +1,3 @@
+@section('scripts')
+    <script src="{{ mix('js/app.js') }}"></script>
+@endsection

--- a/resources/views/post.blade.php
+++ b/resources/views/post.blade.php
@@ -3,6 +3,10 @@
     'metaDescription' => $post->excerpt(160),
 ])
 
+@section('scripts')
+    <script src="{{ mix('js/post.js') }}"></script>
+@endsection
+
 @section('body')
     @component('layouts.header', ['small' => true, 'photo' => 'header-black.jpg'])
     @endcomponent

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -4,6 +4,7 @@ const tailwindcss = require('tailwindcss');
 mix.disableSuccessNotifications();
 mix.copyDirectory('node_modules/@fortawesome/fontawesome-free/webfonts', 'public/webfonts');
 mix.js('resources/js/app.js', 'public/js');
+mix.js('resources/js/post.js', 'public/js');
 mix.sass('resources/sass/app.scss', 'public/css');
 mix.options({
     processCssUrls: false,


### PR DESCRIPTION
This PR work on improving the performance by not loading javascript packages when not needed, I am suggesting two changes.

> All size units mentioned are npm compiled in development mode

1. https://github.com/driesvints/driesvints.com/commit/d970897a6ad63f517de0a103efd2aebc917b243c: Only post pages uses the `highlight.js` package for code syntaxing. I created `post.js` and only loaded `highlight.js` in there. You no longer load that big package on homepage.  **Extracting `highlight.js` from `app.js` reduced its size from `1.69MiB` to `592KiB`**

2. https://github.com/driesvints/driesvints.com/commit/9619ae58c2cc81b312b4b7d486d13dd6a774ed81: lodash isn't used anywhere from what I can see and it comes pre-loaded with Laravel. I took it out. **Removing** lodash reduced `app.js` size from `592KiB` to `62.6KiB`


### Summary
Switched from single js file totals 1.69MiB to two js files totals 654KiB

| File    | Before size | After size |
|---------|-------------|------------|
| app.js  | 1.69 MiB     | 62.6KiB    |
| post.js | 0           | 592KiB     |